### PR TITLE
Fix image meta dict not found during testing

### DIFF
--- a/covid/datamodules/nnunet_datamodule.py
+++ b/covid/datamodules/nnunet_datamodule.py
@@ -223,7 +223,13 @@ class nnUNetDataModule(LightningDataModule):
                         for key in test_keys
                     ]
                 else:
-                    self.test_files = self.val_files
+                    self.test_files = [
+                        {
+                            "data": os.path.join(self.full_data_dir, "%s.npy" % key),
+                            "image_meta_dict": os.path.join(self.full_data_dir, "%s.pkl" % key),
+                        }
+                        for key in val_keys
+                    ]
 
         if stage == TrainerFn.FITTING:
             self.data_train = IterableDataset(


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fixes image meta dict not found during testing when the split only contains train/val splits.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
