### PR TITLE
Fixed bug in `Preprocessd` transform

### DIFF
--- a/ascent/utils/transforms.py
+++ b/ascent/utils/transforms.py
@@ -406,6 +406,7 @@ class Preprocessd(MapTransform):
         image = SpatialCrop(roi_start=box_start, roi_end=box_end)(image)
         image_meta_dict["crop_bbox"] = np.vstack([box_start, box_end])
         image_meta_dict["shape_after_cropping"] = np.array(image.shape[1:])
+        image_meta_dict["spacing_after_resampling"] = self.target_spacing
 
         anisotropy_flag = False
 
@@ -434,7 +435,6 @@ class Preprocessd(MapTransform):
                         # we do not want to resample separately in the out of plane axis
                         anisotropy_flag = False
 
-                image_meta_dict["spacing_after_resampling"] = self.target_spacing
                 image = resample_image(image, resample_shape, anisotropy_flag, axis, 3, 0)
                 if "label" in self.keys:
                     label = label.cpu().detach().numpy()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

During inference, when image's original spacing equals to target spacing, `image_meta_dict["spacing_after_resampling"]` will be not available, but it is required to determine the lowest resolution axis during the resampling process.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
