### PR TITLE
Fix padding bug when image depth is smaller than 6 during prediction

### DIFF
--- a/ascent/models/nnunet_module.py
+++ b/ascent/models/nnunet_module.py
@@ -494,10 +494,14 @@ class nnUNetLitModule(LightningModule):
         if len(image.shape) == 5:
             if len(self.patch_size) == 3:
                 # Pad the last dimension to avoid 3D segmentation border artifacts
+                extra_pad = 0
+                while image.shape[-1] <= 6:
+                    image = pad(image, (1, 1, 0, 0, 0, 0), mode="reflect")
+                    extra_pad += 1
                 image = pad(image, (6, 6, 0, 0, 0, 0), mode="reflect")
                 pred = self.predict_3D_3Dconv_tiled(image, apply_softmax)
                 # Inverse the padding after prediction
-                return pred[..., 6:-6]
+                return pred[..., (6 + extra_pad) : (-6 - extra_pad)]
             elif len(self.patch_size) == 2:
                 return self.predict_3D_2Dconv_tiled(image, apply_softmax)
             else:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fix padding bug when image depth is smaller than 6 during prediction.
- We added a padding of (6, 6) across the last dimension to avoid artifacts

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
