### PR TITLE
Fix last and best checkpoints issue

### DIFF
--- a/ascent/configs/callbacks/latest_checkpoint.yaml
+++ b/ascent/configs/callbacks/latest_checkpoint.yaml
@@ -1,0 +1,19 @@
+# https://pytorch-lightning.readthedocs.io/en/latest/api/lightning.callbacks.ModelCheckpoint.html
+
+# Save the model periodically by monitoring a quantity.
+# Look at the above link for more detailed information.
+latest_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: null # directory to save the model file
+  filename: "latest_epoch_{epoch:03d}" # checkpoint filename
+  monitor: "epoch" # name of the logged metric which determines when model is improving
+  verbose: False # verbosity mode
+  save_last: True # additionally always save an exact copy of the last checkpoint to a file last.ckpt
+  save_top_k: 1 # save k best models (determined by above metric)
+  mode: "max" # "max" means higher metric value is better, can be also "min"
+  auto_insert_metric_name: False # when True, the checkpoints filenames will contain the metric name
+  save_weights_only: False # if True, then only the model’s weights will be saved
+  every_n_train_steps: null # number of training steps between checkpoints
+  train_time_interval: null # checkpoints are monitored at the specified time interval
+  every_n_epochs: 50 # number of epochs between checkpoints
+  save_on_train_epoch_end: null # whether to run checkpointing at the end of the training epoch or the end of validation

--- a/ascent/configs/callbacks/nnunet.yaml
+++ b/ascent/configs/callbacks/nnunet.yaml
@@ -1,5 +1,6 @@
 defaults:
   - model_checkpoint
+  - latest_checkpoint
   - model_summary
   - rich_progress_bar
   - learning_rate_monitor
@@ -7,11 +8,14 @@ defaults:
 
 model_checkpoint:
   dirpath: ${paths.output_dir}/checkpoints
-  filename: "epoch_{epoch:03d}"
+  filename: "best_epoch_{epoch:03d}"
   monitor: "val/dice_MA"
   mode: "max"
   save_last: True
   auto_insert_metric_name: False
+
+latest_checkpoint:
+  dirpath: ${paths.output_dir}/checkpoints
 
 model_summary:
   max_depth: -1


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fix last and best checkpoints issue:
- Lightning's `save_last` in ModelCheckpoint checkpoint does not actually save the last model but creates a symbolic link to the best weight. Hence, it is required to add another ModelCheckpoint callback that monitors `epoch` to save the latest checkpoint.
- Best checkpoint is now saved as `best.ckpt` and `best_epoch_{number}.ckpt`, while last checkpoint is saved as `last.ckpt` and `latest_epoch_{number}.ckpt`.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
