### PR TITLE
Add ONNX conversion feature

### DIFF
--- a/ascent/configs/onnx.yaml
+++ b/ascent/configs/onnx.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - model: mnist
+  - paths: default
+  - override hydra/hydra_logging: disabled
+  - _self_
+
+# model checkpoint path
+ckpt_path: ???
+
+# path to save the converted ONNX model
+onnx_path: ???
+
+# set some default configs to avoid interpolation errors as not all experiment configs are loaded
+model:
+  scheduler:
+    max_decay_steps: 1000
+hydra:
+  output_subdir: null
+  run:
+    dir: .

--- a/ascent/convert_onnx.py
+++ b/ascent/convert_onnx.py
@@ -1,0 +1,103 @@
+from abc import ABC
+from pathlib import Path
+
+import hydra
+import numpy as np
+import onnxruntime
+import torch
+from lightning import LightningModule
+from omegaconf import DictConfig
+
+from ascent import setup_root, utils
+
+log = utils.get_pylogger(__name__)
+
+
+class AscentONNX(ABC):
+    """Abstract converter that converts trained Lightning's model to ONNX format for production."""
+
+    @classmethod
+    def main(cls) -> None:
+        """Runs the requested experiment."""
+        # Set up the environment
+        cls.pre_run_routine()
+
+        # Run the system with config loaded by @hydra.main
+        cls.run_system()
+
+    @classmethod
+    def pre_run_routine(cls) -> None:
+        """Sets-up the environment before running the training/testing."""
+        # Load environment variables from `.env` file if it exists
+        # Load before hydra main to allow for setting environment variables with ${oc.env:ENV_NAME}
+        setup_root()
+
+    @staticmethod
+    @hydra.main(version_base="1.3", config_path="configs", config_name="onnx")
+    def run_system(cfg: DictConfig) -> None:
+        """Loads a model and converts it to ONNX format.
+
+        Args:
+            cfg (DictConfig): Configuration composed by Hydra.
+        """
+
+        def enable_running_stats(model) -> None:
+            """Temporarily enable track_running_stats and initialize running statistics.
+
+            Args:
+                model (torch.nn.Module): The model to modify.
+            """
+            for module in model.modules():
+                if isinstance(module, torch.nn.InstanceNorm2d) or isinstance(
+                    module, torch.nn.InstanceNorm3d
+                ):
+                    num_features = module.num_features
+                    module.running_mean = torch.zeros(num_features, device=model.device)
+                    module.running_var = torch.ones(num_features, device=model.device)
+                    module.track_running_stats = True
+
+        # apply extra utilities
+        # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
+        utils.extras(cfg)
+
+        log.info(f"Instantiating model <{cfg.model._target_}>")
+        model: LightningModule = hydra.utils.instantiate(cfg.model)
+
+        if cfg.get("ckpt_path"):
+            log.info(f"Loading weights from {cfg.ckpt_path}")
+            model.load_state_dict(
+                torch.load(cfg.get("ckpt_path"), map_location=model.device)["state_dict"]
+            )
+
+        log.info("Converting to ONNX format...")
+        filepath = Path(cfg.onnx_path)
+        input_sample = torch.randn((1, model.net.in_channels, *list(model.net.patch_size)))
+        model.eval()
+        # enable_running_stats(model) # This solution is still buggy and needs to be fixed
+        torch.onnx.export(
+            model.net,
+            input_sample,
+            filepath.as_posix(),
+            export_params=True,
+            do_constant_folding=True,
+            input_names=["input"],
+        )
+        # Make sure the converted model produces the same output as the original model
+        with torch.no_grad():
+            original_output = model(input_sample).numpy()
+            ort_session = onnxruntime.InferenceSession(filepath)
+            input_name = ort_session.get_inputs()[0].name
+            ort_inputs = {input_name: input_sample.numpy()}
+            ort_outs = ort_session.run(None, ort_inputs)
+            np.testing.assert_allclose(original_output, ort_outs[0], rtol=1e-03, atol=1e-05)
+            log.info("Model converted successfully and outputs match.")
+        log.info(f"Saving to '{filepath.as_posix()}'")
+
+
+def main():
+    """Run the script."""
+    AscentONNX.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ medpy = "*"
 matplotlib = "*"
 holoviews = "*"
 seaborn = "*"
+onnx = "==1.16.1"
+onnxruntime = "*"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.20.0"
@@ -75,6 +77,7 @@ ascent_train = "ascent.train:main"
 ascent_evaluate = "ascent.eval:main"
 ascent_predict = "ascent.predict:main"
 ascent_preprocess_and_plan = "ascent.preprocess_and_plan:main"
+ascent_onnx = "ascent.convert_onnx:main"
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

`ascent_onnx` now allows the users to convert the trained lightning module to ONNX format.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
